### PR TITLE
refactor: reduce sidebar width on smaller screens

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -37,7 +37,7 @@ export default function RootLayout({
           <Header />
           <main
             id="main"
-            className="pl-[calc(80px+16px)] lg:pl-[calc(240px+28px)] pr-4 lg:pr-[28px] pt-[calc(78px+28px)] pb-[28px] transition-all"
+            className="pl-[calc(60px+16px)] lg:pl-[calc(240px+28px)] pr-4 lg:pr-[28px] pt-[calc(78px+28px)] pb-[28px] transition-all"
           >
             {children}
           </main>

--- a/components/layout/header/index.tsx
+++ b/components/layout/header/index.tsx
@@ -10,7 +10,7 @@ const Header = () => {
   return (
     <header
       id="header"
-      className="fixed top-0 bg-white/70 backdrop-blur-md rounded-b-3xl h-[70px] flex items-center left-[80px] lg:left-[calc(240px+28px)] right-0 lg:right-[28px] transition-all z-40"
+      className="fixed top-0 bg-white/70 backdrop-blur-md rounded-b-3xl h-[70px] flex items-center left-[60px] lg:left-[calc(240px+28px)] right-0 lg:right-[28px] transition-all z-40"
     >
       <div className="px-6 w-full">
         <div className="flex items-center justify-between">

--- a/components/layout/sidebar/LinkItem.tsx
+++ b/components/layout/sidebar/LinkItem.tsx
@@ -24,7 +24,7 @@ const LinkItem = (props: LinkItemProps) => {
         className={cls(
           "flex items-center gap-x-4 py-3 relative transition-all hover:bg-gray-200 hover:rounded-r-full group",
           isActiveRoute(pathname, link) && "bg-gray-200 rounded-r-full",
-          isSidebarActive ? "px-8" : "px-7"
+          isSidebarActive ? "px-8" : "pl-4 lg:px-7"
         )}
       >
         <i

--- a/components/layout/sidebar/index.tsx
+++ b/components/layout/sidebar/index.tsx
@@ -50,7 +50,7 @@ export const Sidebar = () => {
     <aside
       className={cls(
         "sidebar fixed h-full bg-gray-25 transition-all border-r border-r-gray-200 z-50",
-        isSidebarActive ? "w-[240px]" : "w-[80px]"
+        isSidebarActive ? "w-[240px]" : "w-[60px] lg:w-[80px]"
       )}
       id="sidebar"
     >
@@ -61,19 +61,29 @@ export const Sidebar = () => {
             id="logo"
             className={cls(
               "flex items-center relative mb-11",
-              isSidebarActive ? "gap-x-3 px-8" : "px-4"
+              isSidebarActive ? "gap-x-3 px-8" : "px-3 lg:px-4"
             )}
           >
-            <Image
-              src={"/images/logo-base.svg"}
-              width={40}
-              height={40}
-              alt="logo from super.exampl"
-            />
+            {isSidebarActive && (
+              <Image
+                src={"/images/logo-base.svg"}
+                width={40}
+                height={40}
+                alt="logo from super.exampl"
+              />
+            )}
+            {!isSidebarActive && (
+              <Image
+                src={"/images/logo-base.svg"}
+                width={30}
+                height={30}
+                alt="logo from super.exampl"
+              />
+            )}
             <p
               className={cls(
-                "font-heading-font font-medium text-gray-600",
-                isSidebarActive ? "text-2xl" : "absolute opacity-0"
+                "font-heading-font text-2xl font-medium text-gray-600",
+                isSidebarActive ? "" : "absolute opacity-0"
               )}
             >
               Super
@@ -110,9 +120,17 @@ export const Sidebar = () => {
       </div>
 
       <Button
-        className="absolute -right-[11px] top-8"
+        className="hidden md:block absolute -right-[14px] lg:-right-[11px] top-5 lg:top-8"
         icon="chevron"
         size="sm"
+        theme="primary"
+        iconDirection={isSidebarActive ? "left" : "right"}
+        handler={handleSidebarToggle}
+      />
+      <Button
+        className="block md:hidden absolute -right-[14px] lg:-right-[11px] top-5 lg:top-8"
+        icon="chevron"
+        size="xs"
         theme="primary"
         iconDirection={isSidebarActive ? "left" : "right"}
         handler={handleSidebarToggle}

--- a/components/ui/button/index.tsx
+++ b/components/ui/button/index.tsx
@@ -91,7 +91,15 @@ const Button: React.FC<IButton> = (props) => {
         <Icon
           name={icon as "home"}
           size={
-            size === "sm" ? 14 : size === "md" ? 20 : size === "lg" ? 26 : 14
+            size === "xs"
+              ? 10
+              : size === "sm"
+              ? 14
+              : size === "md"
+              ? 20
+              : size === "lg"
+              ? 26
+              : 14
           }
           color={theme === "gray" ? "gray" : iconColor}
           direction={iconDirection}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,11 +3,11 @@
 @tailwind utilities;
 
 .sidebar-collapsed #main {
-  @apply pl-[calc(80px+16px)] lg:pl-[calc(80px+28px)]
+  @apply pl-[calc(60px+16px)] lg:pl-[calc(80px+28px)]
 }
 
 .sidebar-collapsed #header {
-  @apply left-[80px] lg:left-[calc(80px+28px)]
+  @apply left-[60px] lg:left-[calc(80px+28px)]
 }
 
 .link-shape {

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,5 +1,5 @@
 export interface IButton {
-  size?: "sm" | "md" | "lg";
+  size?: "xs" | "sm" | "md" | "lg";
   icon?:
     | "home"
     | "gear"


### PR DESCRIPTION
- Reduced the width of the sidebar on smaller screens to 60px.
- This improves the layout and usability on smaller devices.
- Updated the styling and components to accommodate the change.
- Added a new size "xs" to the Button component.